### PR TITLE
Fix 'Open' URL link in Docker Swarm starter repo.

### DIFF
--- a/replicated.yaml
+++ b/replicated.yaml
@@ -25,6 +25,13 @@ config:
     help_text: Please provide your name
     type: text
     required: true
+  - name: hostname
+    title: Hostname
+    value: '{{repl ConsoleSetting "tls.hostname" }}'
+    type: text
+    test_proc:
+      display_name: Check DNS
+      command: resolve_host
 
 swarm:
   configs:


### PR DESCRIPTION
Fixes the broken "Open" link when launching the demo app.