### PR TITLE
Run Replicated CLI via Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ deps/
 node_modules
 package-lock.json
 test-results
+tmp/
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+MAINTAINER Replicated <support@replicated.com>
+
+RUN apt-get update
+RUN apt-get -y install curl
+
+RUN curl -fsSL https://github.com/replicatedhq/replicated/releases/download/v0.10.0/replicated_0.10.0_linux_amd64.tar.gz | tar xvzf -
+
+ENTRYPOINT ["./replicated"]

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,19 @@ pull-latest-release: deps-vendor-cli
 list-releases: deps-vendor-cli
 	deps/replicated release ls
 
+docker-release:
+	docker run \
+  -e REPLICATED_APP='${REPLICATED_APP}' \
+  -e REPLICATED_API_TOKEN='${REPLICATED_API_TOKEN}' \
+  --mount src=`pwd`,target=/working_dir,type=bind \
+  replicated-cli \
+  release create --promote $(channel) --yaml-file /working_dir/replicated.yaml
+
+docker-list-releases:
+	docker run \
+  -e REPLICATED_APP='${REPLICATED_APP}' \
+  -e REPLICATED_API_TOKEN='${REPLICATED_API_TOKEN}' \
+  --mount src=`pwd`,target=/working_dir,type=bind \
+  replicated-cli \
+  release ls
+

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ $ make watch channel=my-dev-channel
 info gazer-color Watching 1 file[s] (replicated.yaml)
 ```
 
+#### Run CLI in Docker
+
+Use the `Dockerfile` to execute the Replicated CLI inside a container. This is especially helpful if you are running on Windows since `make` and `replicated` cli are not supported. If you have OS X or Linux you can continue using `make`.
+
+Build the image
+```
+docker build -t replicated-cli .
+```
+
+Run Replicated CLI container to verify
+```
+docker run -t replicated-cli --help
+```
+
+If the above command was successful you can run the following `make` commands. If `make` is not available just copy the respective commands from `Makefile` to execute separately.
+
+Note: Complete the 'Configure environment' section as the following commands require those environment variables.
+
+List releases
+```
+make docker-list-releases
+```
+
+Promote a release
+```
+make docker-release
+```
+
 ### Integrating with CI
 
 Often teams will use one channel per developer, and then keep the `master` branch of this repo in sync with their `Unstable` branch.


### PR DESCRIPTION
This is now ready to review. You can test this yourself by running the following commands.


Build the image
```
docker build -t replicated-cli .
```

Run Replicated CLI container to verify
```
docker run -t replicated-cli --help
```

If the above command was successful you can run the following `make` commands. If `make` is not available just copy the respective commands from `Makefile` to execute separately.
Note: Complete the 'Configure environment' section as the following commands require the environment variables.


List releases
```
make docker-list-releases
```

Promote a release
```
make docker-release
```
